### PR TITLE
Security Fix for Resources Downloaded over Insecure Protocol - huntr.dev

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -9,8 +9,8 @@ module.exports = function () {
   var version = '2.11.7';
 
   var bin = new BinWrapper()
-    .src('http://downloads.typesafe.com/scala/' + version + '/scala-' + version + '.tgz', 'darwin')
-    .src('http://downloads.typesafe.com/scala/' + version + '/scala-' + version + '.tgz', 'linux')
+    .src('https://downloads.typesafe.com/scala/' + version + '/scala-' + version + '.tgz', 'darwin')
+    .src('https://downloads.typesafe.com/scala/' + version + '/scala-' + version + '.tgz', 'linux')
     .dest(path.join(path.dirname(__dirname), 'vendor'));
 
   return bluebird.promisifyAll(bin);


### PR DESCRIPTION
https://huntr.dev/users/Mik317 has fixed the Resources Downloaded over Insecure Protocol vulnerability 🔨. Mik317 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/scala-bin/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/scala-bin/1/README.md

### User Comments:

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-scala-bin

### ⚙️ Description *

The `scala-bin` project contained an `install.js` file which downloaded `files` through an `insecure http` connection, making the client vulnerable against `rce` and `file corruption`.

### 💻 Technical Description *

I simply switched the `link` to `https`: the certificate is already verified and `MITM` is no more possible

### 🐛 Proof of Concept (PoC) *

Not needed

### 🔥 Proof of Fix (PoF) *

Not needed

### 👍 User Acceptance Testing (UAT)

I just changed the `https` links and seems no error are thrown